### PR TITLE
Separate MessageStream functionality out into its own class

### DIFF
--- a/android/src/main/java/com/marigold/rnsdk/RNMarigoldModule.kt
+++ b/android/src/main/java/com/marigold/rnsdk/RNMarigoldModule.kt
@@ -1,31 +1,19 @@
 package com.marigold.rnsdk
 
 import android.app.Activity
-import android.content.Intent
 import android.location.Location
 import androidx.annotation.VisibleForTesting
-import com.facebook.react.bridge.WritableNativeArray
-import com.marigold.sdk.Marigold
-import com.marigold.sdk.MessageStream
-import com.marigold.sdk.enums.ImpressionType
-import com.marigold.sdk.model.Message
-import com.marigold.sdk.MessageActivity
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
-import com.facebook.react.bridge.ReadableMap
-import com.facebook.react.bridge.WritableArray
-import com.facebook.react.modules.core.DeviceEventManagerModule
-import org.json.JSONException
-import org.json.JSONObject
+import com.marigold.sdk.Marigold
 import java.lang.reflect.InvocationTargetException
-import java.util.ArrayList
 
 /**
  * React native module for the Marigold SDK.
  */
-class RNMarigoldModule(reactContext: ReactApplicationContext, private val displayInAppNotifications: Boolean) : ReactContextBaseJavaModule(reactContext), MessageStream.OnInAppNotificationDisplayListener {
+class RNMarigoldModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
 
     companion object {
         const val ERROR_CODE_DEVICE = "marigold.device"
@@ -56,26 +44,10 @@ class RNMarigoldModule(reactContext: ReactApplicationContext, private val displa
     var marigold = Marigold()
 
     @VisibleForTesting
-    var messageStream = MessageStream()
-
-    @VisibleForTesting
     internal var jsonConverter: JsonConverter = JsonConverter()
 
     init {
-        messageStream.setOnInAppNotificationDisplayListener(this)
         setWrapperInfo()
-    }
-
-    override fun shouldPresentInAppNotification(message: Message): Boolean {
-        try {
-            val writableMap = jsonConverter.convertJsonToMap(message.toJSON())
-            reactApplicationContext
-                    .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
-                    .emit("inappnotification", writableMap)
-        } catch (e: JSONException) {
-            e.printStackTrace()
-        }
-        return displayInAppNotifications
     }
 
     override fun getName(): String {
@@ -119,118 +91,9 @@ class RNMarigoldModule(reactContext: ReactApplicationContext, private val displa
         })
     }
 
-    @ReactMethod
-    fun getMessages(promise: Promise) {
-        messageStream.getMessages(object : MessageStream.MessagesHandler {
-            override fun onSuccess(messages: ArrayList<Message>) {
-                val array = getWritableArray()
-                try {
-                    val toJsonMethod = Message::class.java.getDeclaredMethod("toJSON")
-                    toJsonMethod.isAccessible = true
-
-                    for (message in messages) {
-                        val messageJson = toJsonMethod.invoke(message) as? JSONObject ?: continue
-                        array.pushMap(jsonConverter.convertJsonToMap(messageJson))
-                    }
-                    promise.resolve(array)
-                } catch (e: NoSuchMethodException) {
-                    promise.reject(ERROR_CODE_MESSAGES, e.message)
-                } catch (e: IllegalAccessException) {
-                    promise.reject(ERROR_CODE_MESSAGES, e.message)
-                } catch (e: JSONException) {
-                    promise.reject(ERROR_CODE_MESSAGES, e.message)
-                } catch (e: InvocationTargetException) {
-                    promise.reject(ERROR_CODE_MESSAGES, e.message)
-                }
-            }
-
-            override fun onFailure(error: Error) {
-                promise.reject(ERROR_CODE_MESSAGES, error.message)
-            }
-        })
-    }
-
-    // Moved out to separate method for testing as WritableNativeArray cannot be mocked
-    fun getWritableArray(): WritableArray {
-        return WritableNativeArray()
-    }
-
-    @ReactMethod
-    fun getUnreadCount(promise: Promise) {
-        messageStream.getUnreadMessageCount(object : MessageStream.MessageStreamHandler<Int> {
-            override fun onSuccess(value: Int) {
-                promise.resolve(value)
-            }
-
-            override fun onFailure(error: Error) {
-                promise.reject(ERROR_CODE_MESSAGES, error.message)
-            }
-        })
-    }
-
-    @ReactMethod
-    fun removeMessage(messageMap: ReadableMap, promise: Promise) {
-        val message = getMessage(messageMap, promise) ?: return
-        messageStream.deleteMessage(message, object : MessageStream.MessageDeletedHandler {
-            override fun onSuccess() {
-                promise.resolve(null)
-            }
-
-            override fun onFailure(error: Error) {
-                promise.reject(ERROR_CODE_MESSAGES, error.message)
-            }
-        })
-    }
-
-    @ReactMethod
-    fun registerMessageImpression(typeCode: Int, messageMap: ReadableMap) {
-        val type = when (typeCode) {
-            0 -> ImpressionType.IMPRESSION_TYPE_IN_APP_VIEW
-            1 -> ImpressionType.IMPRESSION_TYPE_STREAM_VIEW
-            2 -> ImpressionType.IMPRESSION_TYPE_DETAIL_VIEW
-            else -> return
-        }
-        val message = getMessage(messageMap, null) ?: return
-        messageStream.registerMessageImpression(type, message)
-    }
-
-    @ReactMethod
-    fun markMessageAsRead(messageMap: ReadableMap, promise: Promise) {
-        val message = getMessage(messageMap, promise) ?: return
-        messageStream.setMessageRead(message, object : MessageStream.MessagesReadHandler {
-            override fun onSuccess() {
-                promise.resolve(null)
-            }
-
-            override fun onFailure(error: Error) {
-                promise.reject(ERROR_CODE_MESSAGES, error.message)
-            }
-        })
-    }
-
-    @ReactMethod
-    fun presentMessageDetail(message: ReadableMap) {
-        val messageId = message.getString(MESSAGE_ID)
-        val activity = currentActivity()
-        if (messageId == null || activity == null) return
-        val i = getMessageActivityIntent(activity, messageId)
-        activity.startActivity(i)
-    }
-
     // wrapped to expose for testing
     fun currentActivity(): Activity? {
         return currentActivity
-    }
-
-    // wrapped for testing
-    fun getMessageActivityIntent(activity: Activity, messageId: String): Intent {
-        return MessageActivity.intentForMessage(activity, null, messageId)
-    }
-
-    @ReactMethod
-    @SuppressWarnings("unused")
-    fun dismissMessageDetail() {
-        // noop. It's here to share signatures with iOS.
     }
 
     @ReactMethod
@@ -268,23 +131,5 @@ class RNMarigoldModule(reactContext: ReactApplicationContext, private val displa
                 promise.reject(ERROR_CODE_DEVICE, error.message)
             }
         })
-    }
-
-    /*
-     * Helper Methods
-     */
-    @VisibleForTesting
-    fun getMessage(messageMap: ReadableMap, promise: Promise?): Message? = try {
-        val messageJson = jsonConverter.convertMapToJson(messageMap)
-        val constructor = Message::class.java.getDeclaredConstructor(String::class.java)
-        constructor.isAccessible = true
-        constructor.newInstance(messageJson.toString())
-    } catch(e: Exception) {
-        if (promise == null) {
-            e.printStackTrace()
-        } else {
-            promise.reject(ERROR_CODE_MESSAGES, e.message)
-        }
-        null
     }
 }

--- a/android/src/main/java/com/marigold/rnsdk/RNMarigoldPackage.kt
+++ b/android/src/main/java/com/marigold/rnsdk/RNMarigoldPackage.kt
@@ -12,8 +12,9 @@ class RNMarigoldPackage : ReactPackage {
 
     override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
         val modules: MutableList<NativeModule> = ArrayList()
-        modules.add(RNMarigoldModule(reactContext, displayInAppNotifications))
+        modules.add(RNMarigoldModule(reactContext))
         modules.add(RNEngageBySailthruModule(reactContext))
+        modules.add(RNMessageStreamModule(reactContext, displayInAppNotifications))
         return modules
     }
 

--- a/android/src/main/java/com/marigold/rnsdk/RNMessageStreamModule.kt
+++ b/android/src/main/java/com/marigold/rnsdk/RNMessageStreamModule.kt
@@ -1,0 +1,181 @@
+package com.marigold.rnsdk
+
+import android.app.Activity
+import android.content.Intent
+import androidx.annotation.VisibleForTesting
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableArray
+import com.facebook.react.bridge.WritableNativeArray
+import com.facebook.react.modules.core.DeviceEventManagerModule
+import com.marigold.sdk.MessageActivity
+import com.marigold.sdk.MessageStream
+import com.marigold.sdk.enums.ImpressionType
+import com.marigold.sdk.model.Message
+import org.json.JSONException
+import org.json.JSONObject
+import java.lang.reflect.InvocationTargetException
+import java.util.ArrayList
+
+class RNMessageStreamModule (reactContext: ReactApplicationContext, private val displayInAppNotifications: Boolean) : ReactContextBaseJavaModule(reactContext), MessageStream.OnInAppNotificationDisplayListener  {
+    @VisibleForTesting
+    var messageStream = MessageStream()
+
+    @VisibleForTesting
+    internal var jsonConverter: JsonConverter = JsonConverter()
+
+    init {
+        messageStream.setOnInAppNotificationDisplayListener(this)
+    }
+
+    override fun shouldPresentInAppNotification(message: Message): Boolean {
+        try {
+            val writableMap = jsonConverter.convertJsonToMap(message.toJSON())
+            reactApplicationContext
+                    .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+                    .emit("inappnotification", writableMap)
+        } catch (e: JSONException) {
+            e.printStackTrace()
+        }
+        return displayInAppNotifications
+    }
+
+    @ReactMethod
+    fun getMessages(promise: Promise) {
+        messageStream.getMessages(object : MessageStream.MessagesHandler {
+            override fun onSuccess(messages: ArrayList<Message>) {
+                val array = getWritableArray()
+                try {
+                    val toJsonMethod = Message::class.java.getDeclaredMethod("toJSON")
+                    toJsonMethod.isAccessible = true
+
+                    for (message in messages) {
+                        val messageJson = toJsonMethod.invoke(message) as? JSONObject ?: continue
+                        array.pushMap(jsonConverter.convertJsonToMap(messageJson))
+                    }
+                    promise.resolve(array)
+                } catch (e: NoSuchMethodException) {
+                    promise.reject(RNMarigoldModule.ERROR_CODE_MESSAGES, e.message)
+                } catch (e: IllegalAccessException) {
+                    promise.reject(RNMarigoldModule.ERROR_CODE_MESSAGES, e.message)
+                } catch (e: JSONException) {
+                    promise.reject(RNMarigoldModule.ERROR_CODE_MESSAGES, e.message)
+                } catch (e: InvocationTargetException) {
+                    promise.reject(RNMarigoldModule.ERROR_CODE_MESSAGES, e.message)
+                }
+            }
+
+            override fun onFailure(error: Error) {
+                promise.reject(RNMarigoldModule.ERROR_CODE_MESSAGES, error.message)
+            }
+        })
+    }
+
+    @ReactMethod
+    fun getUnreadCount(promise: Promise) {
+        messageStream.getUnreadMessageCount(object : MessageStream.MessageStreamHandler<Int> {
+            override fun onSuccess(value: Int) {
+                promise.resolve(value)
+            }
+
+            override fun onFailure(error: Error) {
+                promise.reject(RNMarigoldModule.ERROR_CODE_MESSAGES, error.message)
+            }
+        })
+    }
+
+    @ReactMethod
+    fun removeMessage(messageMap: ReadableMap, promise: Promise) {
+        val message = getMessage(messageMap, promise) ?: return
+        messageStream.deleteMessage(message, object : MessageStream.MessageDeletedHandler {
+            override fun onSuccess() {
+                promise.resolve(null)
+            }
+
+            override fun onFailure(error: Error) {
+                promise.reject(RNMarigoldModule.ERROR_CODE_MESSAGES, error.message)
+            }
+        })
+    }
+
+    @ReactMethod
+    fun registerMessageImpression(typeCode: Int, messageMap: ReadableMap) {
+        val type = when (typeCode) {
+            0 -> ImpressionType.IMPRESSION_TYPE_IN_APP_VIEW
+            1 -> ImpressionType.IMPRESSION_TYPE_STREAM_VIEW
+            2 -> ImpressionType.IMPRESSION_TYPE_DETAIL_VIEW
+            else -> return
+        }
+        val message = getMessage(messageMap, null) ?: return
+        messageStream.registerMessageImpression(type, message)
+    }
+
+    @ReactMethod
+    fun markMessageAsRead(messageMap: ReadableMap, promise: Promise) {
+        val message = getMessage(messageMap, promise) ?: return
+        messageStream.setMessageRead(message, object : MessageStream.MessagesReadHandler {
+            override fun onSuccess() {
+                promise.resolve(null)
+            }
+
+            override fun onFailure(error: Error) {
+                promise.reject(RNMarigoldModule.ERROR_CODE_MESSAGES, error.message)
+            }
+        })
+    }
+
+    @ReactMethod
+    fun presentMessageDetail(message: ReadableMap) {
+        val messageId = message.getString(RNMarigoldModule.MESSAGE_ID)
+        val activity = currentActivity()
+        if (messageId == null || activity == null) return
+        val i = getMessageActivityIntent(activity, messageId)
+        activity.startActivity(i)
+    }
+
+    // wrapped for testing
+    fun getMessageActivityIntent(activity: Activity, messageId: String): Intent {
+        return MessageActivity.intentForMessage(activity, null, messageId)
+    }
+
+    @ReactMethod
+    @SuppressWarnings("unused")
+    fun dismissMessageDetail() {
+        // noop. It's here to share signatures with iOS.
+    }
+
+    /*
+ * Helper Methods
+ */
+    @VisibleForTesting
+    fun getMessage(messageMap: ReadableMap, promise: Promise?): Message? = try {
+        val messageJson = jsonConverter.convertMapToJson(messageMap)
+        val constructor = Message::class.java.getDeclaredConstructor(String::class.java)
+        constructor.isAccessible = true
+        constructor.newInstance(messageJson.toString())
+    } catch(e: Exception) {
+        if (promise == null) {
+            e.printStackTrace()
+        } else {
+            promise.reject(RNMarigoldModule.ERROR_CODE_MESSAGES, e.message)
+        }
+        null
+    }
+
+    // Moved out to separate method for testing as WritableNativeArray cannot be mocked
+    fun getWritableArray(): WritableArray {
+        return WritableNativeArray()
+    }
+
+    // wrapped to expose for testing
+    fun currentActivity(): Activity? {
+        return currentActivity
+    }
+
+    override fun getName(): String {
+        return "RNMessageStream"
+    }
+}

--- a/android/src/test/java/com/marigold/rnsdk/RNMarigoldModuleTest.kt
+++ b/android/src/test/java/com/marigold/rnsdk/RNMarigoldModuleTest.kt
@@ -1,21 +1,10 @@
 package com.marigold.rnsdk
 
 import android.app.Activity
-import android.content.Intent
 import android.location.Location
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.bridge.ReadableMap
-import com.facebook.react.bridge.WritableArray
-import com.facebook.react.bridge.WritableMap
-import com.facebook.react.modules.core.DeviceEventManagerModule
 import com.marigold.sdk.Marigold
-import com.marigold.sdk.MessageStream
-import com.marigold.sdk.enums.ImpressionType
-import com.marigold.sdk.model.Message
-import org.json.JSONException
-import org.json.JSONObject
-import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -25,7 +14,6 @@ import org.mockito.MockedConstruction
 import org.mockito.Mockito.mockConstruction
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
-import org.mockito.Mockito.times
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.*
 
@@ -40,64 +28,25 @@ class RNMarigoldModuleTest {
     @Mock
     private lateinit var staticMarigold: MockedConstruction<Marigold>
 
-    @Mock
-    private lateinit var staticMessageStream: MockedConstruction<MessageStream>
-
     private lateinit var marigold: Marigold
-    private lateinit var messageStream: MessageStream
 
     private lateinit var rnMarigoldModule: RNMarigoldModule
     private lateinit var rnMarigoldModuleSpy: RNMarigoldModule
 
     @Before
     fun setup() {
-        rnMarigoldModule = RNMarigoldModule(mockContext, true)
+        rnMarigoldModule = RNMarigoldModule(mockContext)
         rnMarigoldModule.jsonConverter = jsonConverter
         rnMarigoldModuleSpy = spy(rnMarigoldModule)
 
         marigold = staticMarigold.constructed()[0]
-        messageStream = staticMessageStream.constructed()[0]
     }
 
     @Test
     fun testConstructor() {
-        verify(messageStream).setOnInAppNotificationDisplayListener(rnMarigoldModule)
         val mockCompanion: RNMarigoldModule.Companion = mock()
         mockCompanion.setWrapperInfo()
         verify(mockCompanion).setWrapperInfo()
-    }
-
-    @Test
-    fun testShouldPresentInAppNotification() {
-        val message: Message = mock()
-        val module: DeviceEventManagerModule.RCTDeviceEventEmitter = mock()
-        val writableMap: WritableMap = mock()
-        val jsonObject: JSONObject = mock()
-
-        doReturn(jsonObject).whenever(message).toJSON()
-        doReturn(writableMap).whenever(jsonConverter).convertJsonToMap(jsonObject)
-        doReturn(module).whenever(mockContext).getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
-
-        val shouldPresent = rnMarigoldModuleSpy.shouldPresentInAppNotification(message)
-
-        verify(mockContext).getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
-        verify(module).emit("inappnotification", writableMap)
-
-        Assert.assertTrue(shouldPresent)
-    }
-
-    @Test
-    fun testShouldPresentInAppNotificationException() {
-        val message: Message = mock()
-        val jsonObject: JSONObject = mock()
-        val jsonException: JSONException = mock()
-        doReturn(jsonObject).whenever(message).toJSON()
-        doThrow(jsonException).whenever(jsonConverter).convertJsonToMap(jsonObject)
-
-        val shouldPresent = rnMarigoldModuleSpy.shouldPresentInAppNotification(message)
-        verify(mockContext, times(0)).getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
-        verify(jsonException).printStackTrace()
-        Assert.assertTrue(shouldPresent)
     }
 
     @Test
@@ -174,244 +123,6 @@ class RNMarigoldModuleTest {
     }
 
     @Test
-    fun testGetMessages() {
-        // Setup mocks
-        val promise: Promise = mock()
-        val writableArray: WritableArray = mock()
-        val error: Error = mock()
-
-        // Initiate test
-        rnMarigoldModuleSpy.getMessages(promise)
-
-        // Capture MessagesHandler to verify behaviour
-        val argumentCaptor = ArgumentCaptor.forClass(MessageStream.MessagesHandler::class.java)
-        verify(messageStream).getMessages(capture(argumentCaptor))
-        val messagesHandler = argumentCaptor.value
-
-        // Replace native array with mock
-        doReturn(writableArray).whenever(rnMarigoldModuleSpy).getWritableArray()
-
-        // Setup message array
-        val messages: ArrayList<Message> = ArrayList()
-
-        // Test success handler
-        messagesHandler.onSuccess(messages)
-        verify(promise).resolve(writableArray)
-
-        // Setup error
-        val errorMessage = "error message"
-        doReturn(errorMessage).whenever(error).message
-
-        // Test error handler
-        messagesHandler.onFailure(error)
-        verify(promise).reject(RNMarigoldModule.ERROR_CODE_MESSAGES, errorMessage)
-    }
-
-    @Test
-    fun testGetUnreadCount() {
-        val unreadCount = 4
-
-        // Setup mocks
-        val promise: Promise = mock()
-        val error: Error = mock()
-
-        // Initiate test
-        rnMarigoldModule.getUnreadCount(promise)
-
-        // Capture MessagesHandler to verify behaviour
-        @SuppressWarnings("unchecked")
-        val argumentCaptor = ArgumentCaptor.forClass(MessageStream.MessageStreamHandler::class.java)
-        verify(messageStream).getUnreadMessageCount(capture(argumentCaptor) as MessageStream.MessageStreamHandler<Int>?)
-        val countHandler = argumentCaptor.value as MessageStream.MessageStreamHandler<Int>
-
-        // Test success handler
-        countHandler.onSuccess(unreadCount)
-        verify(promise).resolve(unreadCount)
-
-        // Setup error
-        val errorMessage = "error message"
-        doReturn(errorMessage).whenever(error).message
-
-        // Test error handler
-        countHandler.onFailure(error)
-        verify(promise).reject(RNMarigoldModule.ERROR_CODE_MESSAGES, errorMessage)
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun testRemoveMessage() {
-        // Create mocks
-        val promise: Promise = mock()
-        val error: Error = mock()
-        val readableMap: ReadableMap = mock()
-        val message: Message = mock()
-        val moduleSpy = spy(rnMarigoldModule)
-        doReturn(message).whenever(moduleSpy).getMessage(readableMap, promise)
-
-        // Initiate test
-        moduleSpy.removeMessage(readableMap, promise)
-
-        // Capture MarigoldHandler to verify behaviour
-        val argumentCaptor = ArgumentCaptor.forClass(MessageStream.MessageDeletedHandler::class.java)
-        verify(messageStream).deleteMessage(eq(message), capture(argumentCaptor))
-        val handler = argumentCaptor.value
-
-        // Test success handler
-        handler.onSuccess()
-        verify(promise).resolve(null)
-
-        // Setup error
-        val errorMessage = "error message"
-        doReturn(errorMessage).whenever(error).message
-
-        // Test error handler
-        handler.onFailure(error)
-        verify(promise).reject(RNMarigoldModule.ERROR_CODE_MESSAGES, errorMessage)
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun testRemoveMessageException() {
-        // Create mocks
-        val promise: Promise = mock()
-        val readableMap: ReadableMap = mock()
-        val jsonException = JSONException("test exception")
-        val moduleSpy = spy(rnMarigoldModule)
-        doThrow(jsonException).whenever(moduleSpy).getMessage(readableMap, promise)
-
-        // Initiate test
-        Assert.assertThrows(JSONException::class.java) {
-            moduleSpy.removeMessage(readableMap, promise)
-            verify(promise).reject(RNMarigoldModule.ERROR_CODE_MESSAGES, jsonException.message)
-        }
-
-        // Verify result
-        verify(messageStream, times(0)).deleteMessage(any(), any())
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun testRegisterMessageImpression() {
-        // Create input
-        val typeCode = 0
-        val readableMap: ReadableMap = mock()
-        val message: Message = mock()
-        doReturn(message).whenever(rnMarigoldModuleSpy).getMessage(readableMap, null)
-
-        // Initiate test
-        rnMarigoldModuleSpy.registerMessageImpression(typeCode, readableMap)
-
-        // Verify result
-        verify(messageStream).registerMessageImpression(ImpressionType.IMPRESSION_TYPE_IN_APP_VIEW, message)
-    }
-
-    @Test
-    fun testRegisterMessageImpressionInvalidCode() {
-        // Create input
-        val typeCode = 10
-        val readableMap: ReadableMap = mock()
-
-        // Initiate test
-        rnMarigoldModuleSpy.registerMessageImpression(typeCode, readableMap)
-
-        // Verify result
-        verify(messageStream, times(0)).registerMessageImpression(any(), any())
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun testRegisterMessageImpressionException() {
-        // Create input
-        val typeCode = 0
-        val readableMap: ReadableMap = mock()
-        val jsonException: JSONException = mock()
-        doThrow(jsonException).whenever(rnMarigoldModuleSpy).getMessage(readableMap, null)
-
-        // Initiate test
-        Assert.assertThrows(Exception::class.java) {
-            rnMarigoldModuleSpy.registerMessageImpression(typeCode, readableMap)
-            verify(jsonException).printStackTrace()
-        }
-
-        // Verify result
-        verify(messageStream, times(0)).registerMessageImpression(any(), any())
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun testMarkMessageAsRead() {
-        // Create mocks
-        val readableMap: ReadableMap = mock()
-        val promise: Promise = mock()
-        val message: Message = mock()
-        val error: Error = mock()
-        val moduleSpy = spy(rnMarigoldModule)
-        doReturn(message).whenever(moduleSpy).getMessage(readableMap, promise)
-
-        // Initiate test
-        moduleSpy.markMessageAsRead(readableMap, promise)
-
-        // Capture MarigoldHandler to verify behaviour
-        val argumentCaptor: ArgumentCaptor<MessageStream.MessagesReadHandler> = ArgumentCaptor.forClass(MessageStream.MessagesReadHandler::class.java)
-        verify(messageStream).setMessageRead(eq(message), capture(argumentCaptor))
-        val handler: MessageStream.MessagesReadHandler = argumentCaptor.value
-
-        // Test success handler
-        handler.onSuccess()
-        verify(promise).resolve(null)
-
-        // Setup error
-        val errorMessage = "error message"
-        doReturn(errorMessage).whenever(error).message
-
-        // Test error handler
-        handler.onFailure(error)
-        verify(promise).reject(RNMarigoldModule.ERROR_CODE_MESSAGES, errorMessage)
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun testMarkMessageAsReadException() {
-        // Create mocks
-        val readableMap: ReadableMap = mock()
-        val promise: Promise = mock()
-        val jsonException = JSONException("test exception")
-        val moduleSpy = spy(rnMarigoldModule)
-        doThrow(jsonException).whenever(moduleSpy).getMessage(readableMap, promise)
-
-        // Initiate test
-        Assert.assertThrows(JSONException::class.java) {
-            moduleSpy.markMessageAsRead(readableMap, promise)
-            verify(promise).reject(RNMarigoldModule.ERROR_CODE_MESSAGES, jsonException.message)
-        }
-
-        // Verify result
-        verify(messageStream, times(0)).setMessageRead(any(), any())
-    }
-
-    @Test
-    fun testPresentMessageDetail() {
-        // Setup input
-        val messageID = "message ID"
-
-        // Setup mocks
-        val message: ReadableMap = mock()
-        val activity: Activity = mock()
-        val intent: Intent = mock()
-
-        // Mock behaviour
-        doReturn(messageID).whenever(message).getString(RNMarigoldModule.MESSAGE_ID)
-        doReturn(activity).whenever(rnMarigoldModuleSpy).currentActivity()
-        doReturn(intent).whenever(rnMarigoldModuleSpy).getMessageActivityIntent(any(), any())
-
-        // Initiate test
-        rnMarigoldModuleSpy.presentMessageDetail(message)
-
-        // Verify result
-        verify(activity).startActivity(intent)
-    }
-
-    @Test
     fun testSetGeoIPTrackingEnabled() {
         // Initiate test
         rnMarigoldModule.setGeoIPTrackingEnabled(true)
@@ -474,22 +185,5 @@ class RNMarigoldModuleTest {
         // Test error handler
         clearHandler.onFailure(error)
         verify(promise).reject(RNMarigoldModule.ERROR_CODE_DEVICE, errorMessage)
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun testGetMessage() {
-        // Mock methods
-        val readableMap: ReadableMap = mock()
-        val promise: Promise = mock()
-        val messageJson = JSONObject().put("title", "test title")
-        doReturn(messageJson).whenever(jsonConverter).convertMapToJson(readableMap)
-
-        // Initiate test
-        val message = rnMarigoldModuleSpy.getMessage(readableMap, promise)
-
-        // Verify result
-        verify(jsonConverter).convertMapToJson(readableMap)
-        Assert.assertEquals("test title", message!!.title)
     }
 }

--- a/android/src/test/java/com/marigold/rnsdk/RNMarigoldPackageTest.kt
+++ b/android/src/test/java/com/marigold/rnsdk/RNMarigoldPackageTest.kt
@@ -17,6 +17,8 @@ class RNMarigoldPackageTest {
     private lateinit var staticRnMarigoldModule: MockedConstruction<RNMarigoldModule>
     @Mock
     private lateinit var staticRnEngageBySailthru: MockedConstruction<RNEngageBySailthruModule>
+    @Mock
+    private lateinit var staticRnMessageStreamModule: MockedConstruction<RNMessageStreamModule>
 
     private lateinit var rnSTPackage: RNMarigoldPackage
 
@@ -28,9 +30,10 @@ class RNMarigoldPackageTest {
     @Test
     fun testCreateNativeModules() {
         val nativeModules = rnSTPackage.createNativeModules(reactApplicationContext)
-        Assert.assertEquals(2, nativeModules.size)
+        Assert.assertEquals(3, nativeModules.size)
         Assert.assertEquals(staticRnMarigoldModule.constructed()[0], nativeModules[0])
         Assert.assertEquals(staticRnEngageBySailthru.constructed()[0], nativeModules[1])
+        Assert.assertEquals(staticRnMessageStreamModule.constructed()[0], nativeModules[2])
     }
 
     @Test

--- a/android/src/test/java/com/marigold/rnsdk/RNMessageStreamModuleTest.kt
+++ b/android/src/test/java/com/marigold/rnsdk/RNMessageStreamModuleTest.kt
@@ -1,0 +1,346 @@
+package com.marigold.rnsdk
+
+import android.app.Activity
+import android.content.Intent
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableArray
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.modules.core.DeviceEventManagerModule
+import com.marigold.sdk.MessageStream
+import com.marigold.sdk.enums.ImpressionType
+import com.marigold.sdk.model.Message
+import org.json.JSONException
+import org.json.JSONObject
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentCaptor
+import org.mockito.Mock
+import org.mockito.MockedConstruction
+import org.mockito.Mockito
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
+import org.mockito.kotlin.capture
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@RunWith(MockitoJUnitRunner::class)
+class RNMessageStreamModuleTest {
+    @Mock
+    private lateinit var mockContext: ReactApplicationContext
+
+    @Mock
+    private lateinit var jsonConverter: JsonConverter
+
+    @Mock
+    private lateinit var staticMessageStream: MockedConstruction<MessageStream>
+
+    private lateinit var messageStream: MessageStream
+
+    private lateinit var rnMessageStreamModule: RNMessageStreamModule
+    private lateinit var rnMessageStreamModuleSpy: RNMessageStreamModule
+
+    @Before
+    fun setup() {
+        rnMessageStreamModule = RNMessageStreamModule(mockContext, true)
+        rnMessageStreamModule.jsonConverter = jsonConverter
+        rnMessageStreamModuleSpy = Mockito.spy(rnMessageStreamModule)
+
+        messageStream = staticMessageStream.constructed()[0]
+    }
+
+    @Test
+    fun testShouldPresentInAppNotification() {
+        val message: Message = mock()
+        val module: DeviceEventManagerModule.RCTDeviceEventEmitter = mock()
+        val writableMap: WritableMap = mock()
+        val jsonObject: JSONObject = mock()
+
+        doReturn(jsonObject).whenever(message).toJSON()
+        doReturn(writableMap).whenever(jsonConverter).convertJsonToMap(jsonObject)
+        doReturn(module).whenever(mockContext).getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+
+        val shouldPresent = rnMessageStreamModuleSpy.shouldPresentInAppNotification(message)
+
+        verify(mockContext).getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+        verify(module).emit("inappnotification", writableMap)
+
+        Assert.assertTrue(shouldPresent)
+    }
+
+    @Test
+    fun testShouldPresentInAppNotificationException() {
+        val message: Message = mock()
+        val jsonObject: JSONObject = mock()
+        val jsonException: JSONException = mock()
+        doReturn(jsonObject).whenever(message).toJSON()
+        doThrow(jsonException).whenever(jsonConverter).convertJsonToMap(jsonObject)
+
+        val shouldPresent = rnMessageStreamModuleSpy.shouldPresentInAppNotification(message)
+        verify(mockContext, Mockito.times(0)).getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+        verify(jsonException).printStackTrace()
+        Assert.assertTrue(shouldPresent)
+    }
+
+    @Test
+    fun testGetMessages() {
+        // Setup mocks
+        val promise: Promise = mock()
+        val writableArray: WritableArray = mock()
+        val error: Error = mock()
+
+        // Initiate test
+        rnMessageStreamModuleSpy.getMessages(promise)
+
+        // Capture MessagesHandler to verify behaviour
+        val argumentCaptor = ArgumentCaptor.forClass(MessageStream.MessagesHandler::class.java)
+        verify(messageStream).getMessages(capture(argumentCaptor))
+        val messagesHandler = argumentCaptor.value
+
+        // Replace native array with mock
+        doReturn(writableArray).whenever(rnMessageStreamModuleSpy).getWritableArray()
+
+        // Setup message array
+        val messages: ArrayList<Message> = ArrayList()
+
+        // Test success handler
+        messagesHandler.onSuccess(messages)
+        verify(promise).resolve(writableArray)
+
+        // Setup error
+        val errorMessage = "error message"
+        doReturn(errorMessage).whenever(error).message
+
+        // Test error handler
+        messagesHandler.onFailure(error)
+        verify(promise).reject(RNMarigoldModule.ERROR_CODE_MESSAGES, errorMessage)
+    }
+
+    @Test
+    fun testGetUnreadCount() {
+        val unreadCount = 4
+
+        // Setup mocks
+        val promise: Promise = mock()
+        val error: Error = mock()
+
+        // Initiate test
+        rnMessageStreamModule.getUnreadCount(promise)
+
+        // Capture MessagesHandler to verify behaviour
+        @SuppressWarnings("unchecked")
+        val argumentCaptor = ArgumentCaptor.forClass(MessageStream.MessageStreamHandler::class.java)
+        verify(messageStream).getUnreadMessageCount(capture(argumentCaptor) as MessageStream.MessageStreamHandler<Int>?)
+        val countHandler = argumentCaptor.value as MessageStream.MessageStreamHandler<Int>
+
+        // Test success handler
+        countHandler.onSuccess(unreadCount)
+        verify(promise).resolve(unreadCount)
+
+        // Setup error
+        val errorMessage = "error message"
+        doReturn(errorMessage).whenever(error).message
+
+        // Test error handler
+        countHandler.onFailure(error)
+        verify(promise).reject(RNMarigoldModule.ERROR_CODE_MESSAGES, errorMessage)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testRemoveMessage() {
+        // Create mocks
+        val promise: Promise = mock()
+        val error: Error = mock()
+        val readableMap: ReadableMap = mock()
+        val message: Message = mock()
+        val moduleSpy = Mockito.spy(rnMessageStreamModule)
+        doReturn(message).whenever(moduleSpy).getMessage(readableMap, promise)
+
+        // Initiate test
+        moduleSpy.removeMessage(readableMap, promise)
+
+        // Capture MarigoldHandler to verify behaviour
+        val argumentCaptor = ArgumentCaptor.forClass(MessageStream.MessageDeletedHandler::class.java)
+        verify(messageStream).deleteMessage(eq(message), capture(argumentCaptor))
+        val handler = argumentCaptor.value
+
+        // Test success handler
+        handler.onSuccess()
+        verify(promise).resolve(null)
+
+        // Setup error
+        val errorMessage = "error message"
+        doReturn(errorMessage).whenever(error).message
+
+        // Test error handler
+        handler.onFailure(error)
+        verify(promise).reject(RNMarigoldModule.ERROR_CODE_MESSAGES, errorMessage)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testRemoveMessageException() {
+        // Create mocks
+        val promise: Promise = mock()
+        val readableMap: ReadableMap = mock()
+        val jsonException = JSONException("test exception")
+        val moduleSpy = Mockito.spy(rnMessageStreamModule)
+        doThrow(jsonException).whenever(moduleSpy).getMessage(readableMap, promise)
+
+        // Initiate test
+        Assert.assertThrows(JSONException::class.java) {
+            moduleSpy.removeMessage(readableMap, promise)
+            verify(promise).reject(RNMarigoldModule.ERROR_CODE_MESSAGES, jsonException.message)
+        }
+
+        // Verify result
+        verify(messageStream, Mockito.times(0)).deleteMessage(any(), any())
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testRegisterMessageImpression() {
+        // Create input
+        val typeCode = 0
+        val readableMap: ReadableMap = mock()
+        val message: Message = mock()
+        doReturn(message).whenever(rnMessageStreamModuleSpy).getMessage(readableMap, null)
+
+        // Initiate test
+        rnMessageStreamModuleSpy.registerMessageImpression(typeCode, readableMap)
+
+        // Verify result
+        verify(messageStream).registerMessageImpression(ImpressionType.IMPRESSION_TYPE_IN_APP_VIEW, message)
+    }
+
+    @Test
+    fun testRegisterMessageImpressionInvalidCode() {
+        // Create input
+        val typeCode = 10
+        val readableMap: ReadableMap = mock()
+
+        // Initiate test
+        rnMessageStreamModuleSpy.registerMessageImpression(typeCode, readableMap)
+
+        // Verify result
+        verify(messageStream, Mockito.times(0)).registerMessageImpression(any(), any())
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testRegisterMessageImpressionException() {
+        // Create input
+        val typeCode = 0
+        val readableMap: ReadableMap = mock()
+        val jsonException: JSONException = mock()
+        doThrow(jsonException).whenever(rnMessageStreamModuleSpy).getMessage(readableMap, null)
+
+        // Initiate test
+        Assert.assertThrows(Exception::class.java) {
+            rnMessageStreamModuleSpy.registerMessageImpression(typeCode, readableMap)
+            verify(jsonException).printStackTrace()
+        }
+
+        // Verify result
+        verify(messageStream, Mockito.times(0)).registerMessageImpression(any(), any())
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testMarkMessageAsRead() {
+        // Create mocks
+        val readableMap: ReadableMap = mock()
+        val promise: Promise = mock()
+        val message: Message = mock()
+        val error: Error = mock()
+        val moduleSpy = Mockito.spy(rnMessageStreamModule)
+        doReturn(message).whenever(moduleSpy).getMessage(readableMap, promise)
+
+        // Initiate test
+        moduleSpy.markMessageAsRead(readableMap, promise)
+
+        // Capture MarigoldHandler to verify behaviour
+        val argumentCaptor: ArgumentCaptor<MessageStream.MessagesReadHandler> = ArgumentCaptor.forClass(MessageStream.MessagesReadHandler::class.java)
+        verify(messageStream).setMessageRead(eq(message), capture(argumentCaptor))
+        val handler: MessageStream.MessagesReadHandler = argumentCaptor.value
+
+        // Test success handler
+        handler.onSuccess()
+        verify(promise).resolve(null)
+
+        // Setup error
+        val errorMessage = "error message"
+        doReturn(errorMessage).whenever(error).message
+
+        // Test error handler
+        handler.onFailure(error)
+        verify(promise).reject(RNMarigoldModule.ERROR_CODE_MESSAGES, errorMessage)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testMarkMessageAsReadException() {
+        // Create mocks
+        val readableMap: ReadableMap = mock()
+        val promise: Promise = mock()
+        val jsonException = JSONException("test exception")
+        val moduleSpy = Mockito.spy(rnMessageStreamModule)
+        doThrow(jsonException).whenever(moduleSpy).getMessage(readableMap, promise)
+
+        // Initiate test
+        Assert.assertThrows(JSONException::class.java) {
+            moduleSpy.markMessageAsRead(readableMap, promise)
+            verify(promise).reject(RNMarigoldModule.ERROR_CODE_MESSAGES, jsonException.message)
+        }
+
+        // Verify result
+        verify(messageStream, Mockito.times(0)).setMessageRead(any(), any())
+    }
+
+    @Test
+    fun testPresentMessageDetail() {
+        // Setup input
+        val messageID = "message ID"
+
+        // Setup mocks
+        val message: ReadableMap = mock()
+        val activity: Activity = mock()
+        val intent: Intent = mock()
+
+        // Mock behaviour
+        doReturn(messageID).whenever(message).getString(RNMarigoldModule.MESSAGE_ID)
+        doReturn(activity).whenever(rnMessageStreamModuleSpy).currentActivity()
+        doReturn(intent).whenever(rnMessageStreamModuleSpy).getMessageActivityIntent(any(), any())
+
+        // Initiate test
+        rnMessageStreamModuleSpy.presentMessageDetail(message)
+
+        // Verify result
+        verify(activity).startActivity(intent)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testGetMessage() {
+        // Mock methods
+        val readableMap: ReadableMap = mock()
+        val promise: Promise = mock()
+        val messageJson = JSONObject().put("title", "test title")
+        doReturn(messageJson).whenever(jsonConverter).convertMapToJson(readableMap)
+
+        // Initiate test
+        val message = rnMessageStreamModuleSpy.getMessage(readableMap, promise)
+
+        // Verify result
+        verify(jsonConverter).convertMapToJson(readableMap)
+        Assert.assertEquals("test title", message!!.title)
+    }
+}


### PR DESCRIPTION
This PR

* Separates the MessageStream from Marigold to have its own class
* adds the MessageStream module to Marigold Package

https://sailthru.atlassian.net/browse/MP-1668