### PR TITLE
[MP-1661] Separate MessageStream functionality out into its own class

### DIFF
--- a/ios/MarigoldSDKReactNative.xcodeproj/project.pbxproj
+++ b/ios/MarigoldSDKReactNative.xcodeproj/project.pbxproj
@@ -7,13 +7,15 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		215B00DBF5AABB974E09F2C4 /* libPods-MarigoldSDKReactNativeTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 773844B95E8A5A7FA0BA7898 /* libPods-MarigoldSDKReactNativeTests.a */; };
-		98F2F01803124DCA63B2D1D0 /* libPods-MarigoldSDKReactNative.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A3DED6FE891CF196EE2638E /* libPods-MarigoldSDKReactNative.a */; };
+		6DA0768DE24958A845077C2B /* libPods-MarigoldSDKReactNative.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CDE475BD8742FC22DFBE98 /* libPods-MarigoldSDKReactNative.a */; };
+		B70342875100E40956188347 /* libPods-MarigoldSDKReactNativeTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 586682E969C08944A97B803E /* libPods-MarigoldSDKReactNativeTests.a */; };
 		B934F55423EA1E68009DE68E /* RNMarigoldBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = B934F55223EA1E68009DE68E /* RNMarigoldBridge.m */; };
 		B934F55623EA1E68009DE68E /* RNMarigold.m in Sources */ = {isa = PBXBuildFile; fileRef = B934F55323EA1E68009DE68E /* RNMarigold.m */; };
 		B934F55A23EA1EE3009DE68E /* RNMarigoldTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B934F55823EA1EE3009DE68E /* RNMarigoldTests.m */; };
 		B934F55B23EA1EE3009DE68E /* RNMarigoldBridgeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B934F55923EA1EE3009DE68E /* RNMarigoldBridgeTests.m */; };
 		E282D1A92B8581F300EECE61 /* RNEngageBySailthruTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E282D1A82B8581F300EECE61 /* RNEngageBySailthruTests.m */; };
+		E2B0BA392B96BFAC008A982B /* RNMessageStream.m in Sources */ = {isa = PBXBuildFile; fileRef = E2B0BA342B96A87D008A982B /* RNMessageStream.m */; };
+		E2B0BA3B2B96BFE7008A982B /* RNMessageStreamTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E2B0BA362B96ABB4008A982B /* RNMessageStreamTests.m */; };
 		E2D064132B882B1800F1ADDB /* RNEngageBySailthru.m in Sources */ = {isa = PBXBuildFile; fileRef = E282D1AA2B85824300EECE61 /* RNEngageBySailthru.m */; };
 /* End PBXBuildFile section */
 
@@ -30,12 +32,12 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		24F5A6848FCB813EFC839F89 /* Pods-MarigoldSDKReactNativeTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MarigoldSDKReactNativeTests.debug.xcconfig"; path = "Target Support Files/Pods-MarigoldSDKReactNativeTests/Pods-MarigoldSDKReactNativeTests.debug.xcconfig"; sourceTree = "<group>"; };
-		3A3DED6FE891CF196EE2638E /* libPods-MarigoldSDKReactNative.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MarigoldSDKReactNative.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		773844B95E8A5A7FA0BA7898 /* libPods-MarigoldSDKReactNativeTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MarigoldSDKReactNativeTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		83FC7AEE353A2A724F42404F /* Pods-MarigoldSDKReactNativeTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MarigoldSDKReactNativeTests.release.xcconfig"; path = "Target Support Files/Pods-MarigoldSDKReactNativeTests/Pods-MarigoldSDKReactNativeTests.release.xcconfig"; sourceTree = "<group>"; };
-		8822A4A7732DB75416D8F285 /* Pods-MarigoldSDKReactNative.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MarigoldSDKReactNative.debug.xcconfig"; path = "Target Support Files/Pods-MarigoldSDKReactNative/Pods-MarigoldSDKReactNative.debug.xcconfig"; sourceTree = "<group>"; };
-		94515BE99D4F5F96FAB2F8CA /* Pods-MarigoldSDKReactNative.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MarigoldSDKReactNative.release.xcconfig"; path = "Target Support Files/Pods-MarigoldSDKReactNative/Pods-MarigoldSDKReactNative.release.xcconfig"; sourceTree = "<group>"; };
+		038EC2E5B0A99461A95D2FC1 /* Pods-MarigoldSDKReactNative.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MarigoldSDKReactNative.release.xcconfig"; path = "Target Support Files/Pods-MarigoldSDKReactNative/Pods-MarigoldSDKReactNative.release.xcconfig"; sourceTree = "<group>"; };
+		28E8275FA0265C1A7936A73F /* Pods-MarigoldSDKReactNativeTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MarigoldSDKReactNativeTests.release.xcconfig"; path = "Target Support Files/Pods-MarigoldSDKReactNativeTests/Pods-MarigoldSDKReactNativeTests.release.xcconfig"; sourceTree = "<group>"; };
+		3E52CE12CE3D03F59B83EC02 /* Pods-MarigoldSDKReactNative.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MarigoldSDKReactNative.debug.xcconfig"; path = "Target Support Files/Pods-MarigoldSDKReactNative/Pods-MarigoldSDKReactNative.debug.xcconfig"; sourceTree = "<group>"; };
+		51947D4C8C2BC095356AD164 /* Pods-MarigoldSDKReactNativeTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MarigoldSDKReactNativeTests.debug.xcconfig"; path = "Target Support Files/Pods-MarigoldSDKReactNativeTests/Pods-MarigoldSDKReactNativeTests.debug.xcconfig"; sourceTree = "<group>"; };
+		586682E969C08944A97B803E /* libPods-MarigoldSDKReactNativeTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MarigoldSDKReactNativeTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		B2CDE475BD8742FC22DFBE98 /* libPods-MarigoldSDKReactNative.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MarigoldSDKReactNative.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B934F55023EA1E67009DE68E /* RNMarigoldBridge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNMarigoldBridge.h; sourceTree = "<group>"; };
 		B934F55123EA1E67009DE68E /* RNMarigold.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNMarigold.h; sourceTree = "<group>"; };
 		B934F55223EA1E68009DE68E /* RNMarigoldBridge.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNMarigoldBridge.m; sourceTree = "<group>"; };
@@ -45,6 +47,9 @@
 		E282D1A82B8581F300EECE61 /* RNEngageBySailthruTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNEngageBySailthruTests.m; sourceTree = "<group>"; };
 		E282D1AA2B85824300EECE61 /* RNEngageBySailthru.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNEngageBySailthru.m; sourceTree = "<group>"; };
 		E282D1AC2B85825400EECE61 /* RNEngageBySailthru.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNEngageBySailthru.h; sourceTree = "<group>"; };
+		E2B0BA332B96A85D008A982B /* RNMessageStream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNMessageStream.h; sourceTree = "<group>"; };
+		E2B0BA342B96A87D008A982B /* RNMessageStream.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNMessageStream.m; sourceTree = "<group>"; };
+		E2B0BA362B96ABB4008A982B /* RNMessageStreamTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNMessageStreamTests.m; sourceTree = "<group>"; };
 		FA5EF5A7213F41AF00D9E6A9 /* libMarigoldSDKReactNative.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libMarigoldSDKReactNative.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		FA5EF5BB213F433200D9E6A9 /* MarigoldSDKReactNativeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MarigoldSDKReactNativeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FA5EF5BF213F433200D9E6A9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -55,7 +60,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				98F2F01803124DCA63B2D1D0 /* libPods-MarigoldSDKReactNative.a in Frameworks */,
+				6DA0768DE24958A845077C2B /* libPods-MarigoldSDKReactNative.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -63,18 +68,18 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				215B00DBF5AABB974E09F2C4 /* libPods-MarigoldSDKReactNativeTests.a in Frameworks */,
+				B70342875100E40956188347 /* libPods-MarigoldSDKReactNativeTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		0DE8FAFD831897900255FA2E /* Frameworks */ = {
+		085873E585CD1328A2C47EBD /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				3A3DED6FE891CF196EE2638E /* libPods-MarigoldSDKReactNative.a */,
-				773844B95E8A5A7FA0BA7898 /* libPods-MarigoldSDKReactNativeTests.a */,
+				B2CDE475BD8742FC22DFBE98 /* libPods-MarigoldSDKReactNative.a */,
+				586682E969C08944A97B803E /* libPods-MarigoldSDKReactNativeTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -82,10 +87,10 @@
 		F3AB1E13B6D82B526F6C9899 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				8822A4A7732DB75416D8F285 /* Pods-MarigoldSDKReactNative.debug.xcconfig */,
-				94515BE99D4F5F96FAB2F8CA /* Pods-MarigoldSDKReactNative.release.xcconfig */,
-				24F5A6848FCB813EFC839F89 /* Pods-MarigoldSDKReactNativeTests.debug.xcconfig */,
-				83FC7AEE353A2A724F42404F /* Pods-MarigoldSDKReactNativeTests.release.xcconfig */,
+				3E52CE12CE3D03F59B83EC02 /* Pods-MarigoldSDKReactNative.debug.xcconfig */,
+				038EC2E5B0A99461A95D2FC1 /* Pods-MarigoldSDKReactNative.release.xcconfig */,
+				51947D4C8C2BC095356AD164 /* Pods-MarigoldSDKReactNativeTests.debug.xcconfig */,
+				28E8275FA0265C1A7936A73F /* Pods-MarigoldSDKReactNativeTests.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -97,7 +102,7 @@
 				FA5EF5BC213F433200D9E6A9 /* MarigoldSDKReactNativeTests */,
 				FA5EF5A8213F41AF00D9E6A9 /* Products */,
 				F3AB1E13B6D82B526F6C9899 /* Pods */,
-				0DE8FAFD831897900255FA2E /* Frameworks */,
+				085873E585CD1328A2C47EBD /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -116,6 +121,7 @@
 				E282D1A82B8581F300EECE61 /* RNEngageBySailthruTests.m */,
 				B934F55923EA1EE3009DE68E /* RNMarigoldBridgeTests.m */,
 				B934F55823EA1EE3009DE68E /* RNMarigoldTests.m */,
+				E2B0BA362B96ABB4008A982B /* RNMessageStreamTests.m */,
 				FA5EF5BF213F433200D9E6A9 /* Info.plist */,
 			);
 			path = MarigoldSDKReactNativeTests;
@@ -130,6 +136,8 @@
 				B934F55323EA1E68009DE68E /* RNMarigold.m */,
 				B934F55023EA1E67009DE68E /* RNMarigoldBridge.h */,
 				B934F55223EA1E68009DE68E /* RNMarigoldBridge.m */,
+				E2B0BA332B96A85D008A982B /* RNMessageStream.h */,
+				E2B0BA342B96A87D008A982B /* RNMessageStream.m */,
 			);
 			name = MarigoldSDKReactNative;
 			sourceTree = "<group>";
@@ -141,7 +149,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = FA5EF5B0213F41AF00D9E6A9 /* Build configuration list for PBXNativeTarget "MarigoldSDKReactNative" */;
 			buildPhases = (
-				2BF45DDCD61AF2663185BC6A /* [CP] Check Pods Manifest.lock */,
+				6BECFBBE6A156281F6954A30 /* [CP] Check Pods Manifest.lock */,
 				FA5EF5A3213F41AF00D9E6A9 /* Sources */,
 				FA5EF5A4213F41AF00D9E6A9 /* Frameworks */,
 				FA5EF5A5213F41AF00D9E6A9 /* CopyFiles */,
@@ -159,12 +167,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = FA5EF5C3213F433200D9E6A9 /* Build configuration list for PBXNativeTarget "MarigoldSDKReactNativeTests" */;
 			buildPhases = (
-				3EC5879E93FB554F9373EB3E /* [CP] Check Pods Manifest.lock */,
+				B65E2DA4BE44EEBA29B94B3F /* [CP] Check Pods Manifest.lock */,
 				FA5EF5B7213F433200D9E6A9 /* Sources */,
 				FA5EF5B8213F433200D9E6A9 /* Frameworks */,
 				FA5EF5B9213F433200D9E6A9 /* Resources */,
-				453FBE4B9DE7EB8460DC9EF0 /* [CP] Embed Pods Frameworks */,
-				91FEB559990CAA3CD3E54E26 /* [CP] Copy Pods Resources */,
+				AB9B1CB65E35E45ED9EBB6E4 /* [CP] Embed Pods Frameworks */,
+				4884A6CA21D6D8AA721B4BCD /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -221,7 +229,24 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		2BF45DDCD61AF2663185BC6A /* [CP] Check Pods Manifest.lock */ = {
+		4884A6CA21D6D8AA721B4BCD /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-MarigoldSDKReactNativeTests/Pods-MarigoldSDKReactNativeTests-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-MarigoldSDKReactNativeTests/Pods-MarigoldSDKReactNativeTests-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-MarigoldSDKReactNativeTests/Pods-MarigoldSDKReactNativeTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		6BECFBBE6A156281F6954A30 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -243,7 +268,24 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		3EC5879E93FB554F9373EB3E /* [CP] Check Pods Manifest.lock */ = {
+		AB9B1CB65E35E45ED9EBB6E4 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-MarigoldSDKReactNativeTests/Pods-MarigoldSDKReactNativeTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-MarigoldSDKReactNativeTests/Pods-MarigoldSDKReactNativeTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-MarigoldSDKReactNativeTests/Pods-MarigoldSDKReactNativeTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		B65E2DA4BE44EEBA29B94B3F /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -265,40 +307,6 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		453FBE4B9DE7EB8460DC9EF0 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-MarigoldSDKReactNativeTests/Pods-MarigoldSDKReactNativeTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-MarigoldSDKReactNativeTests/Pods-MarigoldSDKReactNativeTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-MarigoldSDKReactNativeTests/Pods-MarigoldSDKReactNativeTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		91FEB559990CAA3CD3E54E26 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-MarigoldSDKReactNativeTests/Pods-MarigoldSDKReactNativeTests-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-MarigoldSDKReactNativeTests/Pods-MarigoldSDKReactNativeTests-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-MarigoldSDKReactNativeTests/Pods-MarigoldSDKReactNativeTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -307,6 +315,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E2D064132B882B1800F1ADDB /* RNEngageBySailthru.m in Sources */,
+				E2B0BA392B96BFAC008A982B /* RNMessageStream.m in Sources */,
 				B934F55423EA1E68009DE68E /* RNMarigoldBridge.m in Sources */,
 				B934F55623EA1E68009DE68E /* RNMarigold.m in Sources */,
 			);
@@ -317,6 +326,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E282D1A92B8581F300EECE61 /* RNEngageBySailthruTests.m in Sources */,
+				E2B0BA3B2B96BFE7008A982B /* RNMessageStreamTests.m in Sources */,
 				B934F55A23EA1EE3009DE68E /* RNMarigoldTests.m in Sources */,
 				B934F55B23EA1EE3009DE68E /* RNMarigoldBridgeTests.m in Sources */,
 			);
@@ -441,7 +451,7 @@
 		};
 		FA5EF5B1213F41AF00D9E6A9 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8822A4A7732DB75416D8F285 /* Pods-MarigoldSDKReactNative.debug.xcconfig */;
+			baseConfigurationReference = 3E52CE12CE3D03F59B83EC02 /* Pods-MarigoldSDKReactNative.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
@@ -457,7 +467,7 @@
 		};
 		FA5EF5B2213F41AF00D9E6A9 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 94515BE99D4F5F96FAB2F8CA /* Pods-MarigoldSDKReactNative.release.xcconfig */;
+			baseConfigurationReference = 038EC2E5B0A99461A95D2FC1 /* Pods-MarigoldSDKReactNative.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
@@ -473,7 +483,7 @@
 		};
 		FA5EF5C4213F433200D9E6A9 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 24F5A6848FCB813EFC839F89 /* Pods-MarigoldSDKReactNativeTests.debug.xcconfig */;
+			baseConfigurationReference = 51947D4C8C2BC095356AD164 /* Pods-MarigoldSDKReactNativeTests.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
@@ -493,7 +503,7 @@
 		};
 		FA5EF5C5213F433200D9E6A9 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 83FC7AEE353A2A724F42404F /* Pods-MarigoldSDKReactNativeTests.release.xcconfig */;
+			baseConfigurationReference = 28E8275FA0265C1A7936A73F /* Pods-MarigoldSDKReactNativeTests.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";

--- a/ios/MarigoldSDKReactNativeTests/RNMarigoldBridgeTests.m
+++ b/ios/MarigoldSDKReactNativeTests/RNMarigoldBridgeTests.m
@@ -2,6 +2,7 @@
 #import "RNMarigoldBridge.h"
 #import "RNMarigold.h"
 #import "RNEngageBySailthru.h"
+#import "RNMessageStream.h"
 #import "Kiwi.h"
 
 @interface Marigold ()
@@ -100,16 +101,23 @@ describe(@"RNMarigoldBridge", ^{
         
         it(@"should return RNMarigold in array", ^{
             NSArray *modules = [rnMarigoldBridge extraModulesForBridge:nil];
-            [[theValue(modules.count) should] equal:theValue(2)];
+            [[theValue(modules.count) should] equal:theValue(3)];
             id<RCTBridgeModule> module = [modules objectAtIndex:0];
             [[theValue([module isKindOfClass:[RNMarigold class]]) should] beYes];
         });
         
         it(@"should return RNEngageBySailthru in array", ^{
             NSArray *modules = [rnMarigoldBridge extraModulesForBridge:nil];
-            [[theValue(modules.count) should] equal:theValue(2)];
+            [[theValue(modules.count) should] equal:theValue(3)];
             id<RCTBridgeModule> module = [modules objectAtIndex:1];
             [[theValue([module isKindOfClass:[RNEngageBySailthru class]]) should] beYes];
+        });
+        
+        it(@"should return RNMessageStream in array", ^{
+            NSArray *modules = [rnMarigoldBridge extraModulesForBridge:nil];
+            [[theValue(modules.count) should] equal:theValue(3)];
+            id<RCTBridgeModule> module = [modules objectAtIndex:2];
+            [[theValue([module isKindOfClass:[RNMessageStream class]]) should] beYes];
         });
     });
 });

--- a/ios/MarigoldSDKReactNativeTests/RNMarigoldTests.m
+++ b/ios/MarigoldSDKReactNativeTests/RNMarigoldTests.m
@@ -11,12 +11,6 @@
 -(void)startEngine:(NSString*)sdkKey;
 -(void)resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject;
 -(void)updateLocation:(CGFloat)lat lon:(CGFloat)lon;
--(void)getUnreadCount:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject;
--(void)markMessageAsRead:(NSDictionary*)jsDict resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject;
--(void)removeMessage:(NSDictionary *)jsDict resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject;
--(void)presentMessageDetail:(NSDictionary *)jsDict;
--(void)dismissMessageDetail;
--(void)registerMessageImpression:(NSInteger)impressionType forMessage:(NSDictionary *)jsDict;
 -(void)getDeviceID:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject;
 -(void)setGeoIPTrackingEnabled:(BOOL)enabled;
 -(void)setGeoIPTrackingEnabled:(BOOL)enabled resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject;
@@ -31,13 +25,6 @@
 
 
 // interfaces to match RNMarigold
-
-@interface MARMessage ()
-
-- (nullable instancetype)initWithDictionary:(nonnull NSDictionary *)dictionary;
-- (nonnull NSDictionary *)dictionary;
-
-@end
 @interface Marigold ()
 
 - (void)setWrapperName:(NSString *)wrapperName andVersion:(NSString *)wrapperVersion;
@@ -62,44 +49,14 @@ describe(@"RNMarigold", ^{
         [messageStream stub:@selector(setDelegate:)];
         [MARMessageStream stub:@selector(new) andReturn:messageStream];
         
-        rnMarigold = [[RNMarigold alloc] initWithDisplayInAppNotifications:YES];
+        rnMarigold = [[RNMarigold alloc] init];
     });
     
     context(@"the init method", ^{
-        it(@"should set message stream delegate as self", ^{
-            [[messageStream should] receive:@selector(setDelegate:)];
-            RNMarigold *rnMarigold = [[RNMarigold alloc] init];
-            (void)rnMarigold;
-        });
-        
         it(@"should set the wrapper name and version", ^{
             [[marigold should] receive:@selector(setWrapperName:andVersion:)];
             RNMarigold *rnMarigold = [[RNMarigold alloc] init];
             (void)rnMarigold;
-        });
-        
-        it(@"should set the displayInAppNotifications to YES", ^{
-            RNMarigold *rnMarigold = [[RNMarigold alloc] init];
-            [[theValue(rnMarigold.displayInAppNotifications) should] beYes];
-        });
-    });
-    
-    context(@"the initWithDisplayInAppNotifications method", ^{
-        it(@"should set message stream delegate as self", ^{
-            [[messageStream should] receive:@selector(setDelegate:)];
-            RNMarigold *rnMarigold = [[RNMarigold alloc] initWithDisplayInAppNotifications:YES];
-            (void)rnMarigold;
-        });
-        
-        it(@"should set the wrapper name and version", ^{
-            [[marigold should] receive:@selector(setWrapperName:andVersion:)];
-            RNMarigold *rnMarigold = [[RNMarigold alloc] initWithDisplayInAppNotifications:YES];
-            (void)rnMarigold;
-        });
-        
-        it(@"should set the displayInAppNotifications", ^{
-            RNMarigold *rnMarigold = [[RNMarigold alloc] initWithDisplayInAppNotifications:NO];
-            [[theValue(rnMarigold.displayInAppNotifications) should] beNo];
         });
     });
     
@@ -108,54 +65,6 @@ describe(@"RNMarigold", ^{
             NSString *testKey = @"TESTKEY";
             [[marigold should] receive:@selector(startEngine:withAuthorizationOption:error:) withArguments:testKey, theValue(MARPushAuthorizationOptionNoRequest), nil];
             [rnMarigold startEngine:testKey];
-        });
-    });
-    
-    context(@"the getMessages method", ^{
-        it(@"should call native method", ^{
-            [[messageStream should] receive:@selector(messages:)];
-            [rnMarigold resolver:nil rejecter:nil];
-        });
-        
-        it(@"should return message array on success", ^{
-            // Setup variables
-            __block NSArray *check = nil;
-            NSArray *inputArray = @[];
-            RCTPromiseResolveBlock resolve = ^(NSArray* count) {
-                check = count;
-            };
-            KWCaptureSpy *capture = [messageStream captureArgument:@selector(messages:) atIndex:0];
-            
-            // Start test
-            [rnMarigold resolver:resolve rejecter:nil];
-            
-            // Capture argument
-            void (^completeBlock)(NSArray * _Nullable, NSError * _Nullable) = capture.argument;
-            completeBlock(inputArray, nil);
-            
-            // Verify result
-            [[check shouldNot] beNil];
-            [[check should] beKindOfClass:[NSArray class]];
-        });
-        
-        it(@"should return error on failure", ^{
-            // Setup variables
-            __block NSError *check = nil;
-            RCTPromiseRejectBlock reject = ^(NSString* e, NSString* f, NSError* error) {
-                check = error;
-            };
-            KWCaptureSpy *capture = [messageStream captureArgument:@selector(messages:) atIndex:0];
-            
-            // Start test
-            [rnMarigold resolver:nil rejecter:reject];
-            
-            // Capture argument
-            void (^completeBlock)(NSUInteger, NSError * _Nullable) = capture.argument;
-            NSError *error = [NSError errorWithDomain:@"test" code:1 userInfo:nil];
-            completeBlock(0, error);
-            
-            // Verify result
-            [[check should] equal:error];
         });
     });
     
@@ -170,95 +79,6 @@ describe(@"RNMarigold", ^{
             CLLocation *location = capture.argument;
             [[theValue(location.coordinate.latitude) should] equal:theValue(latitude)];
             [[theValue(location.coordinate.longitude) should] equal:theValue(longitude)];
-        });
-    });
-    
-    context(@"the getUnreadCount method", ^{
-        it(@"should call native method", ^{
-            [[messageStream should] receive:@selector(unreadCount:)];
-            
-            [rnMarigold getUnreadCount:nil rejecter:nil];
-        });
-        
-        it(@"should return count on success", ^{
-            // Setup variables
-            __block NSNumber *check = nil;
-            NSUInteger count = 5;
-            RCTPromiseResolveBlock resolve = ^(NSNumber* count) {
-                check = count;
-            };
-            KWCaptureSpy *capture = [messageStream captureArgument:@selector(unreadCount:) atIndex:0];
-            
-            // Start test
-            [rnMarigold getUnreadCount:resolve rejecter:nil];
-            
-            // Capture argument
-            void (^completeBlock)(NSUInteger, NSError * _Nullable) = capture.argument;
-            completeBlock(count, nil);
-            
-            // Verify result
-            [[check shouldNot] beNil];
-            [[check should] equal:@(count)];
-        });
-        
-        it(@"should return error on failure", ^{
-            // Setup variables
-            __block NSError *check = nil;
-            RCTPromiseRejectBlock reject = ^(NSString* e, NSString* f, NSError* error) {
-                check = error;
-            };
-            KWCaptureSpy *capture = [messageStream captureArgument:@selector(unreadCount:) atIndex:0];
-            
-            // Start test
-            [rnMarigold getUnreadCount:nil rejecter:reject];
-            
-            // Capture argument
-            void (^completeBlock)(NSUInteger, NSError * _Nullable) = capture.argument;
-            NSError *error = [NSError errorWithDomain:@"test" code:1 userInfo:nil];
-            completeBlock(0, error);
-            
-            // Verify result
-            [[check should] equal:error];
-        });
-    });
-    
-    context(@"the markMessageAsRead:resolver:rejecter: method", ^{
-        it(@"should call native method", ^{
-            [[messageStream should] receive:@selector(markMessageAsRead:withResponse:)];
-            
-            [rnMarigold markMessageAsRead:nil resolver:nil rejecter:nil];
-        });
-    });
-    
-    context(@"the removeMessage:resolver:rejecter: method", ^{
-        it(@"should call native method", ^{
-            [[messageStream should] receive:@selector(removeMessage:withResponse:)];
-            
-            [rnMarigold removeMessage:nil resolver:nil rejecter:nil];
-        });
-    });
-    
-    context(@"the presentMessageDetail: method", ^{
-        it(@"should call native method", ^{
-            [[expectFutureValue(messageStream) shouldEventuallyBeforeTimingOutAfter(5)] receive:@selector(presentMessageDetailForMessage:)];
-            
-            [rnMarigold presentMessageDetail:nil];
-        });
-    });
-    
-    context(@"the dismissMessageDetail method", ^{
-        it(@"should call native method", ^{
-            [[expectFutureValue(messageStream) shouldEventuallyBeforeTimingOutAfter(5)] receive:@selector(dismissMessageDetail)];
-            
-            [rnMarigold dismissMessageDetail];
-        });
-    });
-    
-    context(@"the registerMessageImpression:forMessage: method", ^{
-        it(@"should call native method", ^{
-            [[messageStream should] receive:@selector(registerImpressionWithType:forMessage:)];
-            
-            [rnMarigold registerMessageImpression:1 forMessage:nil];
         });
     });
     

--- a/ios/MarigoldSDKReactNativeTests/RNMessageStreamTests.m
+++ b/ios/MarigoldSDKReactNativeTests/RNMessageStreamTests.m
@@ -1,0 +1,190 @@
+#import <XCTest/XCTest.h>
+#import "RNMessageStream.h"
+#import "Kiwi.h"
+#import <UserNotifications/UserNotifications.h>
+
+// interface to expose methods for testing
+@interface RNMessageStream ()
+
+-(void)resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject;
+-(void)getUnreadCount:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject;
+-(void)markMessageAsRead:(NSDictionary*)jsDict resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject;
+-(void)removeMessage:(NSDictionary *)jsDict resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject;
+-(void)presentMessageDetail:(NSDictionary *)jsDict;
+-(void)dismissMessageDetail;
+-(void)registerMessageImpression:(NSInteger)impressionType forMessage:(NSDictionary *)jsDict;
+
+@end
+
+SPEC_BEGIN(RNMessageStreamSpec)
+
+describe(@"RNMessageStream", ^{
+    __block MARMessageStream *messageStream = nil;
+    __block RNMessageStream *rnMessageStream = nil;
+
+    beforeEach(^{
+        messageStream = [MARMessageStream mock];
+        [messageStream stub:@selector(setDelegate:)];
+        [MARMessageStream stub:@selector(new) andReturn:messageStream];
+        rnMessageStream = [RNMessageStream new];
+    });
+    
+    context(@"the init method", ^{
+        it(@"should set the displayInAppNotifications to YES", ^{
+            RNMessageStream *rnMessageStream = [[RNMessageStream alloc] initWithDisplayInAppNotifications:YES];
+            [[theValue(rnMessageStream.displayInAppNotifications) should] beYes];
+        });
+    });
+    
+    context(@"the initWithDisplayInAppNotifications method", ^{
+        it(@"should set message stream delegate as self", ^{
+            [[messageStream should] receive:@selector(setDelegate:)];
+            RNMessageStream *rnMessageStream = [[RNMessageStream alloc] initWithDisplayInAppNotifications:YES];
+            (void)rnMessageStream;
+        });
+        
+        it(@"should set the displayInAppNotifications", ^{
+            RNMessageStream *rnMessageStream = [[RNMessageStream alloc] initWithDisplayInAppNotifications:NO];
+            [[theValue(rnMessageStream.displayInAppNotifications) should] beNo];
+        });
+    });
+    
+    context(@"the getMessages method", ^{
+        it(@"should call native method", ^{
+            [[messageStream should] receive:@selector(messages:)];
+            [rnMessageStream resolver:nil rejecter:nil];
+        });
+        
+        it(@"should return message array on success", ^{
+            // Setup variables
+            __block NSArray *check = nil;
+            NSArray *inputArray = @[];
+            RCTPromiseResolveBlock resolve = ^(NSArray* count) {
+                check = count;
+            };
+            KWCaptureSpy *capture = [messageStream captureArgument:@selector(messages:) atIndex:0];
+            
+            // Start test
+            [rnMessageStream resolver:resolve rejecter:nil];
+            
+            // Capture argument
+            void (^completeBlock)(NSArray * _Nullable, NSError * _Nullable) = capture.argument;
+            completeBlock(inputArray, nil);
+            
+            // Verify result
+            [[check shouldNot] beNil];
+            [[check should] beKindOfClass:[NSArray class]];
+        });
+        
+        it(@"should return error on failure", ^{
+            // Setup variables
+            __block NSError *check = nil;
+            RCTPromiseRejectBlock reject = ^(NSString* e, NSString* f, NSError* error) {
+                check = error;
+            };
+            KWCaptureSpy *capture = [messageStream captureArgument:@selector(messages:) atIndex:0];
+            
+            // Start test
+            [rnMessageStream resolver:nil rejecter:reject];
+            
+            // Capture argument
+            void (^completeBlock)(NSUInteger, NSError * _Nullable) = capture.argument;
+            NSError *error = [NSError errorWithDomain:@"test" code:1 userInfo:nil];
+            completeBlock(0, error);
+            
+            // Verify result
+            [[check should] equal:error];
+        });
+    });
+    
+    context(@"the getUnreadCount method", ^{
+        it(@"should call native method", ^{
+            [[messageStream should] receive:@selector(unreadCount:)];
+            
+            [rnMessageStream getUnreadCount:nil rejecter:nil];
+        });
+        
+        it(@"should return count on success", ^{
+            // Setup variables
+            __block NSNumber *check = nil;
+            NSUInteger count = 5;
+            RCTPromiseResolveBlock resolve = ^(NSNumber* count) {
+                check = count;
+            };
+            KWCaptureSpy *capture = [messageStream captureArgument:@selector(unreadCount:) atIndex:0];
+            
+            // Start test
+            [rnMessageStream getUnreadCount:resolve rejecter:nil];
+            
+            // Capture argument
+            void (^completeBlock)(NSUInteger, NSError * _Nullable) = capture.argument;
+            completeBlock(count, nil);
+            
+            // Verify result
+            [[check shouldNot] beNil];
+            [[check should] equal:@(count)];
+        });
+        
+        it(@"should return error on failure", ^{
+            // Setup variables
+            __block NSError *check = nil;
+            RCTPromiseRejectBlock reject = ^(NSString* e, NSString* f, NSError* error) {
+                check = error;
+            };
+            KWCaptureSpy *capture = [messageStream captureArgument:@selector(unreadCount:) atIndex:0];
+            
+            // Start test
+            [rnMessageStream getUnreadCount:nil rejecter:reject];
+            
+            // Capture argument
+            void (^completeBlock)(NSUInteger, NSError * _Nullable) = capture.argument;
+            NSError *error = [NSError errorWithDomain:@"test" code:1 userInfo:nil];
+            completeBlock(0, error);
+            
+            // Verify result
+            [[check should] equal:error];
+        });
+    });
+    
+    context(@"the markMessageAsRead:resolver:rejecter: method", ^{
+        it(@"should call native method", ^{
+            [[messageStream should] receive:@selector(markMessageAsRead:withResponse:)];
+            
+            [rnMessageStream markMessageAsRead:nil resolver:nil rejecter:nil];
+        });
+    });
+    
+    context(@"the removeMessage:resolver:rejecter: method", ^{
+        it(@"should call native method", ^{
+            [[messageStream should] receive:@selector(removeMessage:withResponse:)];
+            
+            [rnMessageStream removeMessage:nil resolver:nil rejecter:nil];
+        });
+    });
+    
+    context(@"the presentMessageDetail: method", ^{
+        it(@"should call native method", ^{
+            [[expectFutureValue(messageStream) shouldEventuallyBeforeTimingOutAfter(5)] receive:@selector(presentMessageDetailForMessage:)];
+            
+            [rnMessageStream presentMessageDetail:nil];
+        });
+    });
+    
+    context(@"the dismissMessageDetail method", ^{
+        it(@"should call native method", ^{
+            [[expectFutureValue(messageStream) shouldEventuallyBeforeTimingOutAfter(5)] receive:@selector(dismissMessageDetail)];
+            
+            [rnMessageStream dismissMessageDetail];
+        });
+    });
+    
+    context(@"the registerMessageImpression:forMessage: method", ^{
+        it(@"should call native method", ^{
+            [[messageStream should] receive:@selector(registerImpressionWithType:forMessage:)];
+            
+            [rnMessageStream registerMessageImpression:1 forMessage:nil];
+        });
+    });
+});
+
+SPEC_END

--- a/ios/RNEngageBySailthru.m
+++ b/ios/RNEngageBySailthru.m
@@ -23,7 +23,7 @@ RCT_EXPORT_MODULE();
 }
 
 - (NSArray<NSString *> *)supportedEvents {
-    return @[@"inappnotification"];
+    return @[];
 }
 
 #pragma mark - Attributes

--- a/ios/RNMarigold.h
+++ b/ios/RNMarigold.h
@@ -6,16 +6,6 @@
 
 @interface RNMarigold : RCTEventEmitter <RCTBridgeModule, MARMessageStreamDelegate>
 
-@property BOOL displayInAppNotifications;
-
-/**
- * Initialize RNMarigold and set whether to automatically display in app notifications.\
- *
- * @param displayInAppNotifications set whether the SDK should automatically display in app notifications.
- * @return RNMarigold instance.
- */
--(instancetype)initWithDisplayInAppNotifications:(BOOL)displayInAppNotifications;
-
 /**
  * Return array of supported RN events.
  *

--- a/ios/RNMarigold.m
+++ b/ios/RNMarigold.m
@@ -1,13 +1,7 @@
 
 #import "RNMarigold.h"
+#import "RNMessageStream.h"
 #import <UserNotifications/UserNotifications.h>
-
-@interface MARMessage ()
-
-- (nullable instancetype)initWithDictionary:(nonnull NSDictionary *)dictionary;
-- (nonnull NSDictionary *)dictionary;
-
-@end
 
 @interface Marigold ()
 
@@ -24,7 +18,6 @@
 @interface RNMarigold()
 
 @property (nonatomic, strong) Marigold *marigold;
-@property (nonatomic, strong) MARMessageStream *messageStream;
 
 @end
 
@@ -35,19 +28,8 @@
 RCT_EXPORT_MODULE();
 
 - (instancetype)init {
-    return [self initWithDisplayInAppNotifications:YES];
-}
-
-- (instancetype)initWithDisplayInAppNotifications:(BOOL)displayNotifications {
-    self = [super init];
-    if(self) {
-        _displayInAppNotifications = displayNotifications;
-        _marigold = [Marigold new];
-        _messageStream = [MARMessageStream new];
-
-        [_messageStream setDelegate:self];
-        [_marigold setWrapperName:@"React Native" andVersion:@"10.0.0"];
-    }
+    _marigold = [Marigold new];
+    [_marigold setWrapperName:@"React Native" andVersion:@"10.0.0"];
     return self;
 }
 
@@ -59,34 +41,9 @@ RCT_EXPORT_MODULE();
     return @[@"inappnotification"];
 }
 
-- (BOOL)shouldPresentInAppNotificationForMessage:(MARMessage *)message {
-    NSMutableDictionary *payload = [NSMutableDictionary dictionaryWithDictionary:[message dictionary]];
-
-    if ([message attributes]) {
-        [payload setObject:[message attributes] forKey:@"attributes"];
-    }
-
-    [self sendEventWithName:@"inappnotification" body:payload];
-    return self.displayInAppNotifications;
-}
-
 RCT_EXPORT_METHOD(startEngine:(NSString *)sdkKey) {
     [self dispatchOnMainQueue:^{
         [self.marigold startEngine:sdkKey withAuthorizationOption:MARPushAuthorizationOptionNoRequest error:nil];
-    }];
-}
-
-#pragma mark - Messages
-// Note: We use promises for our return values, not callbacks.
-
-RCT_REMAP_METHOD(getMessages, resolver:(RCTPromiseResolveBlock)resolve
-                 rejecter:(RCTPromiseRejectBlock)reject) {
-    [self.messageStream messages:^(NSArray * _Nullable messages, NSError * _Nullable error) {
-        if (error) {
-            [RNMarigold rejectPromise:reject withError:error];
-        } else {
-            resolve([RNMarigold arrayOfMessageDictionariesFromMessageArray:messages]);
-        }
     }];
 }
 
@@ -94,58 +51,6 @@ RCT_REMAP_METHOD(getMessages, resolver:(RCTPromiseResolveBlock)resolve
 
 RCT_EXPORT_METHOD(updateLocation:(CGFloat)lat lon:(CGFloat)lon) {
     [self.marigold updateLocation:[[CLLocation alloc] initWithLatitude:lat longitude:lon]];
-}
-
-#pragma mark - Message Stream
-
-RCT_EXPORT_METHOD(getUnreadCount:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject) {
-    [self.messageStream unreadCount:^(NSUInteger unreadCount, NSError * _Nullable error) {
-        if (error) {
-            [RNMarigold rejectPromise:reject withError:error];
-        } else {
-            resolve(@(unreadCount));
-        }
-    }];
-}
-
-
-RCT_EXPORT_METHOD(markMessageAsRead:(NSDictionary*)jsDict resolver:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject) {
-    [self.messageStream markMessageAsRead:[RNMarigold messageFromDict:jsDict] withResponse:^(NSError * _Nullable error) {
-        if (error) {
-            [RNMarigold rejectPromise:reject withError:error];
-        } else {
-            resolve(nil);
-        }
-    }];
-}
-
-RCT_EXPORT_METHOD(removeMessage:(NSDictionary *)jsDict resolver:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject) {
-    [self.messageStream removeMessage:[RNMarigold messageFromDict:jsDict] withResponse:^(NSError * _Nullable error) {
-        if (error) {
-            [RNMarigold rejectPromise:reject withError:error];
-        } else {
-            resolve(nil);
-        }
-    }];
-}
-
-RCT_EXPORT_METHOD(presentMessageDetail:(NSDictionary *)jsDict) {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self.messageStream presentMessageDetailForMessage:[RNMarigold messageFromDict:jsDict]];
-    });
-}
-
-RCT_EXPORT_METHOD(dismissMessageDetail) {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self.messageStream dismissMessageDetail];
-    });
-}
-
-RCT_EXPORT_METHOD(registerMessageImpression:(NSInteger)impressionType forMessage:(NSDictionary *)jsDict) {
-    [self.messageStream registerImpressionWithType:impressionType forMessage:[RNMarigold messageFromDict:jsDict]];
 }
 
 #pragma mark - IDs
@@ -210,23 +115,10 @@ RCT_EXPORT_METHOD(clearDevice:(NSInteger)options resolver:(RCTPromiseResolveBloc
     }];
 }
 
-#pragma mark - Helper Fuctions
+#pragma mark - Helper Functions
 
 + (void)rejectPromise:(RCTPromiseRejectBlock)reject withError:(NSError *)error {
     reject([NSString stringWithFormat:@"%ld", error.code], error.localizedDescription, error);
-}
-
-
-+ (NSArray *)arrayOfMessageDictionariesFromMessageArray:(NSArray *)messageArray {
-    NSMutableArray *messageDictionaries = [NSMutableArray array];
-    for (MARMessage *message in messageArray) {
-        [messageDictionaries addObject:[message dictionary]];
-    }
-    return messageDictionaries;
-}
-
-+ (MARMessage *) messageFromDict:(NSDictionary *)jsDict {
-    return [[MARMessage alloc] initWithDictionary:jsDict];
 }
 
 - (void)dispatchOnMainQueue:(dispatch_block_t) block {

--- a/ios/RNMarigold.m
+++ b/ios/RNMarigold.m
@@ -38,7 +38,7 @@ RCT_EXPORT_MODULE();
 }
 
 - (NSArray<NSString *> *)supportedEvents {
-    return @[@"inappnotification"];
+    return @[];
 }
 
 RCT_EXPORT_METHOD(startEngine:(NSString *)sdkKey) {

--- a/ios/RNMarigoldBridge.m
+++ b/ios/RNMarigoldBridge.m
@@ -2,6 +2,7 @@
 #import "RNMarigoldBridge.h"
 #import "RNMarigold.h"
 #import "RNEngageBySailthru.h"
+#import "RNMessageStream.h"
 #import <Marigold/Marigold.h>
 #import <Marigold/EngageBySailthru.h>
 
@@ -26,9 +27,10 @@
 }
 
 - (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge {
-    RNMarigold *rnMarigold = [[RNMarigold alloc] initWithDisplayInAppNotifications:self.displayInAppNotifications];
+    RNMarigold *rnMarigold = [[RNMarigold alloc] init];
     RNEngageBySailthru *rnEngageBySailthru = [[RNEngageBySailthru alloc] init];
-    NSArray *modules = @[ rnMarigold, rnEngageBySailthru ];
+    RNMessageStream *rnMessageStream = [[RNMessageStream alloc] initWithDisplayInAppNotifications:self.displayInAppNotifications];
+    NSArray *modules = @[ rnMarigold, rnEngageBySailthru, rnMessageStream ];
     return modules;
 }
 

--- a/ios/RNMessageStream.h
+++ b/ios/RNMessageStream.h
@@ -1,0 +1,26 @@
+
+#import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
+
+#include <Marigold/Marigold.h>
+
+@interface RNMessageStream : RCTEventEmitter <RCTBridgeModule, MARMessageStreamDelegate>
+
+@property BOOL displayInAppNotifications;
+
+/**
+ * Initialize RNMarigold and set whether to automatically display in app notifications.\
+ *
+ * @param displayInAppNotifications set whether the SDK should automatically display in app notifications.
+ * @return RNMarigold instance.
+ */
+-(instancetype)initWithDisplayInAppNotifications:(BOOL)displayInAppNotifications;
+
+
+/**
+ * Return array of supported RN events.
+ *
+ * @return array containing supported events strings.
+ */
+- (NSArray<NSString *> *)supportedEvents;
+@end

--- a/ios/RNMessageStream.m
+++ b/ios/RNMessageStream.m
@@ -18,6 +18,8 @@
 
 @implementation RNMessageStream
 
+RCT_EXPORT_MODULE();
+
 - (instancetype)init {
     return [self initWithDisplayInAppNotifications:YES];
 }

--- a/ios/RNMessageStream.m
+++ b/ios/RNMessageStream.m
@@ -1,0 +1,135 @@
+
+#import "RNMessageStream.h"
+#import <UserNotifications/UserNotifications.h>
+
+@interface MARMessage ()
+
+- (nullable instancetype)initWithDictionary:(nonnull NSDictionary *)dictionary;
+- (nonnull NSDictionary *)dictionary;
+
+@end
+
+@interface RNMessageStream()
+
+@property (nonatomic, strong) MARMessageStream *messageStream;
+
+@end
+
+
+@implementation RNMessageStream
+
+- (instancetype)init {
+    return [self initWithDisplayInAppNotifications:YES];
+}
+
+- (instancetype)initWithDisplayInAppNotifications:(BOOL)displayNotifications {
+    self = [super init];
+    if(self) {
+        _displayInAppNotifications = displayNotifications;
+        _messageStream = [MARMessageStream new];
+
+        [_messageStream setDelegate:self];
+    }
+    return self;
+}
+
+- (NSArray<NSString *> *)supportedEvents {
+    return @[@"inappnotification"];
+}
+
+- (BOOL)shouldPresentInAppNotificationForMessage:(MARMessage *)message {
+    NSMutableDictionary *payload = [NSMutableDictionary dictionaryWithDictionary:[message dictionary]];
+
+    if ([message attributes]) {
+        [payload setObject:[message attributes] forKey:@"attributes"];
+    }
+
+    [self sendEventWithName:@"inappnotification" body:payload];
+    return self.displayInAppNotifications;
+}
+
+#pragma mark - Messages
+// Note: We use promises for our return values, not callbacks.
+
+RCT_REMAP_METHOD(getMessages, resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject) {
+    [self.messageStream messages:^(NSArray * _Nullable messages, NSError * _Nullable error) {
+        if (error) {
+            [RNMessageStream rejectPromise:reject withError:error];
+        } else {
+            resolve([RNMessageStream arrayOfMessageDictionariesFromMessageArray:messages]);
+        }
+    }];
+}
+
+#pragma mark - Message Stream
+
+RCT_EXPORT_METHOD(getUnreadCount:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    [self.messageStream unreadCount:^(NSUInteger unreadCount, NSError * _Nullable error) {
+        if (error) {
+            [RNMessageStream rejectPromise:reject withError:error];
+        } else {
+            resolve(@(unreadCount));
+        }
+    }];
+}
+
+
+RCT_EXPORT_METHOD(markMessageAsRead:(NSDictionary*)jsDict resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    [self.messageStream markMessageAsRead:[RNMessageStream messageFromDict:jsDict] withResponse:^(NSError * _Nullable error) {
+        if (error) {
+            [RNMessageStream rejectPromise:reject withError:error];
+        } else {
+            resolve(nil);
+        }
+    }];
+}
+
+RCT_EXPORT_METHOD(removeMessage:(NSDictionary *)jsDict resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    [self.messageStream removeMessage:[RNMessageStream messageFromDict:jsDict] withResponse:^(NSError * _Nullable error) {
+        if (error) {
+            [RNMessageStream rejectPromise:reject withError:error];
+        } else {
+            resolve(nil);
+        }
+    }];
+}
+
+RCT_EXPORT_METHOD(presentMessageDetail:(NSDictionary *)jsDict) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self.messageStream presentMessageDetailForMessage:[RNMessageStream messageFromDict:jsDict]];
+    });
+}
+
+RCT_EXPORT_METHOD(dismissMessageDetail) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self.messageStream dismissMessageDetail];
+    });
+}
+
+RCT_EXPORT_METHOD(registerMessageImpression:(NSInteger)impressionType forMessage:(NSDictionary *)jsDict) {
+    [self.messageStream registerImpressionWithType:impressionType forMessage:[RNMessageStream messageFromDict:jsDict]];
+}
+
+#pragma mark - Helper Functions
+
++ (void)rejectPromise:(RCTPromiseRejectBlock)reject withError:(NSError *)error {
+    reject([NSString stringWithFormat:@"%ld", error.code], error.localizedDescription, error);
+}
+
++ (NSArray *)arrayOfMessageDictionariesFromMessageArray:(NSArray *)messageArray {
+    NSMutableArray *messageDictionaries = [NSMutableArray array];
+    for (MARMessage *message in messageArray) {
+        [messageDictionaries addObject:[message dictionary]];
+    }
+    return messageDictionaries;
+}
+
++ (MARMessage *) messageFromDict:(NSDictionary *)jsDict {
+    return [[MARMessage alloc] initWithDictionary:jsDict];
+}
+
+@end


### PR DESCRIPTION
This PR:
Separates the MessageStream from Marigold to have its own class 
Adds the MessageStream module to Marigold Bridge