### PR TITLE
[MP-1733] React Native (iOS): Add `setInAppNotificationsEnabled` method

### DIFF
--- a/ios/MarigoldSDKReactNativeTests/RNMarigoldTests.m
+++ b/ios/MarigoldSDKReactNativeTests/RNMarigoldTests.m
@@ -20,6 +20,7 @@
 -(void)registerForPushNotifications;
 -(void)syncNotificationSettings;
 -(void)clearDevice:(NSInteger)options resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject;
+-(void)setInAppNotificationsEnabled:(BOOL)enabled;
 
 @end
 
@@ -298,6 +299,14 @@ describe(@"RNMarigold", ^{
             [[marigold should] receive:@selector(syncNotificationSettings)];
             
             [rnMarigold syncNotificationSettings];
+        });
+    });
+    
+    context(@"the setInAppNotificationsEnabled: method", ^{
+        it(@"should call native method", ^{
+            [[marigold should] receive:@selector(setInAppNotificationsEnabled:)];
+            
+            [rnMarigold setInAppNotificationsEnabled:YES];
         });
     });
     

--- a/ios/RNMarigold.m
+++ b/ios/RNMarigold.m
@@ -115,6 +115,10 @@ RCT_EXPORT_METHOD(clearDevice:(NSInteger)options resolver:(RCTPromiseResolveBloc
     }];
 }
 
+RCT_EXPORT_METHOD(setInAppNotificationsEnabled:(BOOL)enabled) {
+    [self.marigold setInAppNotificationsEnabled:enabled];
+}
+
 #pragma mark - Helper Functions
 
 + (void)rejectPromise:(RCTPromiseRejectBlock)reject withError:(NSError *)error {


### PR DESCRIPTION
This PR: Adds the setInAppNotificationsEnabled in the Marigold Class

Task: https://sailthru.atlassian.net/browse/MP-1733