### PR TITLE
Add MIT licence to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,5 +52,6 @@
   ],
   "scripts": {
     "test": "jest --verbose"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
This PR adds a reference to the MIT licence to the package.json so that it will be visible in the published NPM package.